### PR TITLE
Add RSS to blog

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,6 +4,7 @@ project:
 
 website:
   title: "Dieters Blog"
+  site-url: "https://christofhenkel.github.io/dieters-blog-v2/"
   navbar:
     right:
       - about.qmd
@@ -11,10 +12,9 @@ website:
         href: https://github.com/christofhenkel
       - icon: twitter
         href: https://twitter.com/kagglingdieter
+      - icon: rss
+        href: https://christofhenkel.github.io/dieters-blog-v2/index.xml
 format:
   html:
     theme: cosmo
     css: styles.css
-
-
-

--- a/index.qmd
+++ b/index.qmd
@@ -7,6 +7,7 @@ listing:
   categories: true
   sort-ui: false
   filter-ui: false
+  feed: true
 page-layout: full
 title-block-banner: false
 ---


### PR DESCRIPTION
Quarto doesn't seem to enable RSS feeds by default. Hoping you might consider this PR which will add an RSS feed to your blog.